### PR TITLE
Catch exceptions from implementations of ProjectItem

### DIFF
--- a/OpenFileInSolutionPackage.cs
+++ b/OpenFileInSolutionPackage.cs
@@ -105,7 +105,7 @@ namespace PerniciousGames.OpenFileInSolution
         /// </summary>
         protected override void Initialize()
         {
-            Debug.WriteLine (string.Format(CultureInfo.CurrentCulture, "Entering Initialize() of: {0}", this.ToString()));
+            Debug.WriteLine(string.Format(CultureInfo.CurrentCulture, "Entering Initialize() of: {0}", this.ToString()));
             base.Initialize();
 
             OleMenuCommandService mcs = GetService(typeof(IMenuCommandService)) as OleMenuCommandService;
@@ -180,17 +180,24 @@ namespace PerniciousGames.OpenFileInSolution
                 for (int i = 1; i <= items.Count; i++)
                 {
                     var itm = items.Item(i);
-                    var itmGuid = Guid.Parse(itm.Kind);
-
+                    
                     foreach (var res in EnumerateProjectItems(itm.ProjectItems))
                     {
                         yield return res;
                     }
 
-                    if (itmGuid.Equals(ProjectVirtualFolderGuid)
-                        || itmGuid.Equals(ProjectFolderGuid))
+                    try
                     {
-                        continue;
+                        var itmGuid = Guid.Parse(itm.Kind);
+                        if (itmGuid.Equals(ProjectVirtualFolderGuid)
+                            || itmGuid.Equals(ProjectFolderGuid))
+                        {
+                            continue;
+                        }
+                    }
+                    catch (Exception)
+                    {
+                        // itm.Kind may throw an exception with certain node types like WixExtension (COMException)
                     }
 
                     for (short j = 0; itm != null && j < itm.FileCount; j++)

--- a/README.md
+++ b/README.md
@@ -1,2 +1,19 @@
-VSQuickOpenFile
-===============
+# VSQuickOpenFile
+
+Quickly display a list of files in your solution for opening. Supports searching by filename or path. Functions just like `Shift`+`Alt`+`O` in Visual Assist.
+
+![Quick Open File](openfileinsolution.png?raw=true "Quick Open File")
+
+This extension will parse the projects in your solution and look for files. Once it has built a list of these files, it allows you to search through them for the file you want to open and open it quickly. It supports searching for pieces of the filename in any order and can easily highlight multiple files with just the keyboard to open all at once.
+
+## Usage
+- Use the "Open File In Solution" entry at the top of the Tools menu.
+- Set a key binding for Tools.OpenFileInSolution 
+
+## Installation
+[Download](https://marketplace.visualstudio.com/items?itemName=PerniciousGames.OpenFileInSolution) this extension from the Visual Studio Marketplace.
+
+## Future improvements:
+- Need to cache the list of files in the solution so it doesn't have to re-parse them every time. This means updating the cached list when new files/projects are added or loaded.
+- More options for controlling how files are listed and searched, such as the ability to only search through open files. 
+


### PR DESCRIPTION
OpenFileInSolution throws an exception for me in solutions with a Wix project type, and the window never displays.

![Member not found exception](https://user-images.githubusercontent.com/3628071/38312745-81d3370c-37f0-11e8-9b9f-9127462ed53f.png)

The root cause of this seems to be Wix not properly implementing ProjectItem, since `.Kind` should return a GUID.
![Wix ProjectItem properties](https://user-images.githubusercontent.com/3628071/38312946-f700082a-37f0-11e8-8490-365a815a771c.png)

Since this exception is thrown in a getter, I couldn't think of any way to avoid it throwing so it is wrapped in a try/catch. There was no noticeable performance impact.

The exception is thrown in multiple Wix project types, so it would get a messy if we tried to maintain an ignore list. It's also likely other custom project types could throw this exception so even though Wix is at fault, I believe OpenFileInSolution benefits from this change. Looking forward to hearing what you think though.

I also added the description info and screenshot to the readme (which you OK'ed in my last PR). This project needs to be appreciated, it's critical for my workflow because it is so much faster than built-in VS search! Thanks again.